### PR TITLE
Supported Platforms: Standardize documentation structure

### DIFF
--- a/docs/overview/supported-platforms/freebsd.md
+++ b/docs/overview/supported-platforms/freebsd.md
@@ -51,7 +51,7 @@ shellhub_tenant_id="00000000-0000-0000-0000-000000000000"
 If you don't know how to get your Tenant ID, see [Retrieving Your Tenant ID](/user-guides/namespaces/retrieving-your-tenant-id)
 :::
 
-## Step 4: Starting the ShellHub Agent
+## Starting ShellHub Agent and Testing
 
 To start the ShellHub Agent, use:
 
@@ -62,6 +62,29 @@ service shellhub start
 The ShellHub Agent will now connect in the background using the specified server address and tenant ID.
 
 ![](/img/pending-device-notification.png)
+
+## Troubleshooting Tips
+
+- **Network Connectivity:** Ensure the device can reach the ShellHub server.
+- **Tenant ID & Server Address:** Double-check the variable content reading `/etc/rc.conf`. Also verify if all variables are correctly spelled.
+- **Logs and Debugging:**
+Check the ShellHub Agent logs for detailed error messages by running `cat /var/log/shellhub.log`. Look for messages indicating connection issues, authentication errors, or misconfigurations.
+- **Service Status:**
+Ensure the ShellHub service is running by checking its status `service shellhub status`. If the service is not running, try starting it: `service shellhub start`.
+- **System Updates:**
+Ensure your FreeBSD system and ports tree are up-to-date to avoid compatibility issues:
+
+```bash
+freebsd-update fetch install
+portsnap fetch update
+```
+
+## ShellHub Environment Variables for FreeBSD
+
+- **shellhub_enable:** Enable or disable ShellHub Agent. By default, it is set to `NO`. Set it to `YES` to enable shellhub.
+- **shellhub_server_address:** Sets the address for the ShellHub server (default is ShellHub Cloud: https://cloud.shellhub.io).
+- **shellhub_private_key:** Path to the device’s private key.y default, it is stored in `/etc/shellhub.key`
+- **shellhub_tenant_id:** Links the device to a specific tenant or namespace.
 
 ## Conclusion
 

--- a/docs/overview/supported-platforms/snap.md
+++ b/docs/overview/supported-platforms/snap.md
@@ -64,9 +64,29 @@ sudo snap set shellhub server-address=<your-server-address>
 If you don't know how to get your Tenant ID, see [Retrieving Your Tenant ID](/user-guides/namespaces/retrieving-your-tenant-id)
 :::
 
+## Starting ShellHub Agent and Testing
+
 The ShellHub Agent will automatically connect to the server in background.
 
 ![](/img/pending-device-notification.png)
+
+## Troubleshooting Tips
+
+- **Network Connectivity:** Ensure the device can reach the ShellHub server.
+- **Tenant ID & Server Address:** Double-check the variable content values using `snap get shellhub`. Also verify if all variables are correctly spelled.
+- **Logs and Debugging:**
+ Check the ShellHub Agent logs for detailed error messages by running `sudo snap logs shellhub`.
+- **Restarting the ShellHub Agent:**
+  After updating configuration settings, restart the ShellHub Agent to apply changes: `sudo snap restart shellhub`.
+- **Updating the ShellHub Snap Package:**
+  Ensure the ShellHub Snap is up-to-date by running:`sudo snap refresh shellhub`.
+
+## ShellHub Environment Variables for Snap
+
+- **server-address:** Sets the address for the ShellHub server (default is ShellHub Cloud: https://cloud.shellhub.io).
+- **private-key:** Path to the device’s private key.
+- **tenant-id:** Links the device to a specific tenant or namespace.
+- **preferred-hostname:** Suggested hostname for the device, if available.
 
 ## Conclusion
 

--- a/docs/overview/supported-platforms/yocto.md
+++ b/docs/overview/supported-platforms/yocto.md
@@ -77,7 +77,7 @@ Replace `<image-name>` with your target image (e.g., `core-image-base`).
 - **Dependencies:** Verify all necessary dependencies for the ShellHub Agent are met.
 - **Yocto Variables:** Ensure all Yocto configuration variables are correctly spelled.
 
-## ShellHub Environment Variables
+## ShellHub Environment Variables for Yocto Project
 
 - **SHELLHUB_SERVER_ADDRESS:** Sets the address for the ShellHub server (default is ShellHub Cloud: https://cloud.shellhub.io).
 - **SHELLHUB_PRIVATE_KEY:** Path to the device’s private key.


### PR DESCRIPTION
Even each platform requires different approaches, since some are aimed at build systems (and not a operating system itself), this commit aims to standardize the structure between each supported platform documentation.