### PR TITLE
fix: yocto project guide: use packagegroup instead the package itself

### DIFF
--- a/docs/overview/supported-platforms/yocto.md
+++ b/docs/overview/supported-platforms/yocto.md
@@ -36,7 +36,7 @@ If you don't know how to get your Tenant ID, see [Retrieving Your Tenant ID](/us
 Edit the `conf/local.conf` file to add these variables:
 
 ```bash
-CORE_IMAGE_EXTRA_INSTALL += "shellhub-agent"
+CORE_IMAGE_EXTRA_INSTALL += "packagegroup-shellhub-runtime"
 SHELLHUB_TENANT_ID = "<your tenant id here>"
 ```
 


### PR DESCRIPTION
Although installing the package itself works perfectly, it is considered good practice to add a packagegroup, as it provides more flexibility (e.g., shellhub-agent.bb can be renamed, or other packages can be added to the packagegroup).