### PR TITLE
chore: migrate Renovate config syntax

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,28 +1,33 @@
 {
-  "extends": ["config:base"],
-  "regexManagers": [
+  "extends": [
+    "config:recommended"
+  ],
+  "customManagers": [
     {
-      "fileMatch": ["^src/config\\.js$"],
+      "fileMatch": [
+        "^src/config\\.js$"
+      ],
       "matchStrings": [
         "version:\\s*\"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\""
       ],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "shellhub-io/shellhub",
-      "versioningTemplate": "semver"
+      "versioningTemplate": "semver",
+      "customType": "regex"
     }
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": [
+      "enabled": false,
+      "matchPackageNames": [
         "*"
-      ],
-      "enabled": false
+      ]
     },
     {
-      "matchPackagePatterns": [
+      "enabled": true,
+      "matchPackageNames": [
         "shellhub-io/shellhub"
-      ],
-      "enabled": true
+      ]
     }
   ]
 }


### PR DESCRIPTION
This updates the Renovate config flagged by the Dependency Dashboard's **Config Migration Needed** section.

Changes are limited to Renovate's current config syntax:
- `config:base` -> `config:recommended`
- `regexManagers` -> `customManagers` with `customType: "regex"`
- `matchPackagePatterns` -> `matchPackageNames`

I preserved the existing `shellhub-io/shellhub` tag tracking behavior for `src/config.js` and left the package-rule enable/disable intent unchanged.

Validation: `python3 -m json.tool .github/renovate.json` and `git diff --check`.