### PR TITLE
docs(self-hosted): fix upgrade guide for postgres-only release

### DIFF
--- a/docs/self-hosted/upgrading.md
+++ b/docs/self-hosted/upgrading.md
@@ -30,15 +30,23 @@ Make sure to backup all database data files before proceeding with upgrade.
 ## Database Migration (MongoDB to PostgreSQL)
 
 Starting with **v0.23.0**, ShellHub introduced a migration pipeline that automatically
-copies all data from MongoDB to PostgreSQL. In **v0.24.0**, PostgreSQL became the default
-and only supported database backend. MongoDB is no longer required.
+copies all data from MongoDB to PostgreSQL. In **v0.24.0**, PostgreSQL became the only
+supported database backend: MongoDB, the `SHELLHUB_DATABASE=migrate` mode, and the
+migration pipeline were all removed.
 
-### How the migration works
+:::caution
+The migration only runs on **v0.23.x**. If you still keep data in MongoDB, upgrade to
+v0.23.x and complete the migration **before** moving to v0.24.0 or later. There is no
+in-place MongoDB-to-PostgreSQL migration on v0.24.0+ — jumping straight from MongoDB to
+v0.24.0 leaves that data behind.
+:::
 
-The migration runs automatically on startup when `SHELLHUB_DATABASE` is set to `migrate`.
-It reads all data from MongoDB, writes it to PostgreSQL, and performs a full validation
-to ensure data integrity. The migration status is visible at `GET /api/migration/status`
-and in the web UI.
+### How the migration works (v0.23.x)
+
+On v0.23.x, the migration runs automatically on startup when `SHELLHUB_DATABASE` is set
+to `migrate`. It reads all data from MongoDB, writes it to PostgreSQL, and performs a
+full validation to ensure data integrity. Check the progress at
+`GET /api/migration/status` (available on v0.23.x), in the web UI, or in the API logs.
 
 Once the migration completes successfully, you can switch to PostgreSQL permanently.
 
@@ -48,11 +56,13 @@ If you are upgrading from v0.22.x or earlier, follow these steps:
 
 1. **Backup your MongoDB data** before doing anything.
 
-2. **Upgrade to v0.23.0 first**. The default `SHELLHUB_DATABASE` is already set to
-   `migrate` in the `.env` file, so no additional configuration is needed.
+2. **Upgrade to v0.23.x first**. The default `SHELLHUB_DATABASE` is already set to
+   `migrate` in the `.env` file, so no additional configuration is needed. Do not skip
+   this release — it is the only one that can migrate your MongoDB data.
 
-3. Start ShellHub and wait for the migration to complete. You can check the status at
-   `GET /api/migration/status` — it will return `{"status":"completed"}` when done.
+3. Start ShellHub and wait for the migration to complete. On v0.23.x you can check the
+   status at `GET /api/migration/status` — it returns `{"status":"completed"}` when done —
+   or follow the web UI and the API logs.
 
 4. Verify the migration completed without errors by checking the API logs.
 
@@ -61,12 +71,6 @@ If you are upgrading from v0.22.x or earlier, follow these steps:
 
 6. Start ShellHub. It will now use PostgreSQL directly. MongoDB is no longer needed.
 
-:::tip
-If you are upgrading directly from v0.22.x or earlier to v0.24.0, you can skip v0.23.0
-entirely. Set `SHELLHUB_DATABASE=migrate` in your `.env.override`, let the migration
-complete, then remove it and restart so it falls back to the default `postgres`.
-:::
-
 :::caution
 Do not remove your MongoDB data or container until you have verified that the migration
 completed successfully and PostgreSQL is working correctly.
@@ -74,7 +78,7 @@ completed successfully and PostgreSQL is working correctly.
 
 ### Upgrading from v0.23.x
 
-If you already ran v0.23.0 with `SHELLHUB_DATABASE=migrate` and the migration completed
+If you already ran v0.23.x with `SHELLHUB_DATABASE=migrate` and the migration completed
 successfully, simply update to v0.24.0. The default database is already set to `postgres`.
 
 ## Upgrade to Enterprise Edition


### PR DESCRIPTION
## What
Updates the "Database Migration (MongoDB to PostgreSQL)" section of the self-hosted upgrade guide to match the PostgreSQL-only release (v0.24.0).

## Why
The `SHELLHUB_DATABASE=migrate` mode, its migration pipeline, and the `GET /api/migration/status` endpoint were removed in v0.24.0 (shellhub-io/shellhub#6429). They only ever existed in v0.23.x, but the guide presented them as a current migration path — including a tip telling users to run `migrate` mode directly on v0.24.0, which no longer works.

## Changes
- Reframed the migration as a **v0.23.x-only** step and added a prominent caution: the migration must be completed on v0.23.x **before** upgrading to v0.24.0+; there is no in-place migration on v0.24.0+.
- Scoped the `GET /api/migration/status` references to **v0.23.x** (where the endpoint exists, alongside the web UI and API logs), and noted in the intro caution that the endpoint and the `migrate` mode were removed in v0.24.0. The references were not deleted — they were clarified as a v0.23.x feature.
- Removed the incorrect tip that told users to skip v0.23.0 and set `SHELLHUB_DATABASE=migrate` directly on v0.24.0.
- Kept the existing version facts and the MongoDB-data backup cautions.

## Related
Follow-up to shellhub-io/shellhub#6429 / shellhub-io/cloud#2386 (MongoDB store removal).