### PR TITLE
chore: gitignore Claude Code context symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ yarn-error.log*
 
 # Claude Code context files (symlinked from private repo)
 **/CLAUDE.md
+**/CONTEXT.md
+/docs/adr


### PR DESCRIPTION
## What

Ignores `CONTEXT.md` and `docs/adr`, which `workspace.sh` symlinks in from the
private `claude/` config repo, so the local symlinks are not committed here.

## Why

`**/CLAUDE.md` was already ignored; `CONTEXT.md` and the ADR directory arrive by
the same mechanism and were not.

## Changes

- **`.gitignore`**: adds `**/CONTEXT.md` and `/docs/adr` under the existing
  Claude Code comment, rather than repeating the same comment before each entry.